### PR TITLE
feat: add individual car savings per year to the car search results display

### DIFF
--- a/assets/js/fuel-saving-calculator.js
+++ b/assets/js/fuel-saving-calculator.js
@@ -63,20 +63,20 @@ function displayCalculationResults(savingAmount) {
 
 // Fuel Savings Calculator
 
-function calculateFuelSavings(fuelPrice=4.23) {
+function calculateFuelSavings(individualDisplay=false, customElectricKwhUsage) {
     // Per Gallon in dollars
     // Check if custom fuel price is supplied
+    var fuelPrice=4.23
     if (customFuelPrice.value) {
         if (customFuelPrice.value > 0 && validateMPGInput(value) == true) {
-            console.log(customFuelPrice.value);
             fuelPrice = customFuelPrice.value;
-        } else {
+        } else if (customFuelPrice.value > 0 && validateMPGInput(value) == false) {
             alert("Please enter a valid input for Fuel Price");
+            return False;
         }
     }
     // Check if custom vehicle MPG is supplied
     let vehicleMPG = document.getElementById("mpgValue").innerHTML;
-    console.log(vehicleMPG);
     if (vehicleMPG == "Unselected") {
         vehicleMPG = 36;
     } 
@@ -84,23 +84,29 @@ function calculateFuelSavings(fuelPrice=4.23) {
     // Per kWh in cents
     const electricityPrice = 13.72;
     // mile per kWh, Changes dependant on the car displayed?
-    const electricKwhUsage = 4;
+    if (individualDisplay == true) {
+        var electricKwhUsage = customElectricKwhUsage
+    } else {
+        var electricKwhUsage = 4;
+    }
     
     // Store variables from page
     let mileage = document.getElementById("mileageValue").innerHTML;
     if (mileage == "Unselected") {
         mileage = 30000;
-    } 
-
-    const vehicleType =  document.getElementById("vehicle-type");
+    }
     
     // Calculate the difference in yearly cost
     let electricYearCost = ((mileage / electricKwhUsage) * electricityPrice)/100;
     let fuelYearCost = (mileage / vehicleMPG) * fuelPrice;
     let yearCostSaving = Math.round((fuelYearCost - electricYearCost) * 100) / 100;
     
-    if (yearCostSaving > 0) {
-        displayCalculationResults(yearCostSaving)
+    if (individualDisplay == false) {
+        if (yearCostSaving > 0) {
+            displayCalculationResults(yearCostSaving)
+        }
+    } else {
+        return yearCostSaving
     }
 }
 

--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -48,6 +48,8 @@ function displaySearchResults(resultsList) {
         }
         // for all the items in the results, display thier info on screen
         for (const car of resultsList) {
+            carFuelSavings = calculateFuelSavings(true, 1/car['m/kWh'])
+            savingStatement =  `<p class="mb-0 text-success">Save approx $${carFuelSavings} a year with this EV!</p>`
             display.innerHTML += `
             <div class="card car-display-card">
                 <div class="card-header">
@@ -60,6 +62,7 @@ function displaySearchResults(resultsList) {
                     <p class="mb-0">Battery Capacity - ${car['BATTERY CAPACITY']}</p>
                     <p class="mb-0">Miles Per Kilo Watt Hour - ${car['m/kWh']}</p>
                     <p class="mb-0">Price - $${car['PRICE']}</p>
+                    ${carFuelSavings > 0 ?  savingStatement : ""}
                 </div>
             </div>
             `
@@ -88,7 +91,7 @@ function searchButtonClick() {
         alert("please select your car budget above")
         return false;
     } else {
-        // collect data from the local database
+        // collect data from the local database https://alissatroiano.github.io/team-4-april-2022/electric.json
         fetch("https://alissatroiano.github.io/team-4-april-2022/electric.json")
         .then(
             response => response.json()

--- a/electric.json
+++ b/electric.json
@@ -8,7 +8,7 @@
   "VEHICLE CLASS": "Compact",
   "ENGINE POWER": "61 kW",
   "BATTERY CAPACITY": "36.8 kWh",
-  "m/kWh": "0.41 kWh",
+  "m/kWh": 0.41,
   "PRICE": "22,000 USD",
   "data_price": 22000
 },{
@@ -21,7 +21,7 @@
   "VEHICLE CLASS": "Mid-Size",
   "ENGINE POWER": "375 kW",
   "BATTERY CAPACITY": "100 kWh",
-  "m/kWh": "0.31 kWh",
+  "m/kWh": 0.31,
   "PRICE": "94,990 USD",
   "data_price": 94990
 },{
@@ -34,7 +34,7 @@
   "VEHICLE CLASS": "Compact",
   "ENGINE POWER": "83 kW",
   "BATTERY CAPACITY": "24 kWh",
-  "m/kWh": "0.3 kWh",
+  "m/kWh": 0.3,
   "PRICE": "32,500 USD",
   "data_price": 32500
 },{
@@ -47,7 +47,7 @@
   "VEHICLE CLASS": "Compact",
   "ENGINE POWER": "125 kW",
   "BATTERY CAPACITY": "42.2 kWh",
-  "m/kWh": "0.29 kWh",
+  "m/kWh": 0.29,
   "PRICE": "44,450 USD",
   "data_price": 44450
 },{
@@ -60,7 +60,7 @@
   "VEHICLE CLASS": "SUV",
   "ENGINE POWER": "198 kWh",
   "BATTERY CAPACITY": "75.7",
-  "m/kWh": "0.34 kWh",
+  "m/kWh": 0.34,
   "PRICE": "43,895 USD",
   "data_price": 43895
 },{
@@ -73,7 +73,7 @@
   "VEHICLE CLASS": "SUV",
   "ENGINE POWER": "100 kW",
   "BATTERY CAPACITY": "39.2 kWh",
-  "m/kWh": "0.27 kWh",
+  "m/kWh": 0.27,
   "PRICE": "28,450 USD",
   "data_price": 28450
 },{
@@ -86,7 +86,7 @@
   "VEHICLE CLASS": "Mid-Size",
   "ENGINE POWER": "101 kW",
   "BATTERY CAPACITY": "38.3 kWh",
-  "m/kWh": "0.25 kWh",
+  "m/kWh": 0.25,
   "PRICE": "47,140 USD",
   "data_price": 47140
 },{
@@ -99,7 +99,7 @@
   "VEHICLE CLASS": "SUV",
   "ENGINE POWER": "81 kW",
   "BATTERY CAPACITY": "31.8 kWh",
-  "m/kWh": "0.31 kWh",
+  "m/kWh": 0.31,
   "PRICE": "21,430 USD",
   "data_price": 21430
 },{
@@ -112,7 +112,7 @@
   "VEHICLE CLASS": "Mid-Size",
   "ENGINE POWER": "150 kW",
   "BATTERY CAPACITY": "64 kWh",
-  "m/kWh": "0.3 kWh",
+  "m/kWh": 0.3,
   "PRICE": "38,500 USD",
   "data_price": 38500
 },{
@@ -125,7 +125,7 @@
   "VEHICLE CLASS": "Mid-Size",
   "ENGINE POWER": "135 kW",
   "BATTERY CAPACITY": "32.6 kWh",
-  "m/kWh": "0.31 kWh",
+  "m/kWh": 0.31,
   "PRICE": "34,750 USD",
   "data_price": 34750
 },{
@@ -138,7 +138,7 @@
   "VEHICLE CLASS": "Mid-Size",
   "ENGINE POWER": "110 kW",
   "BATTERY CAPACITY": "40 kWh",
-  "m/kWh": "0.32 kWh",
+  "m/kWh": 0.32,
   "PRICE": "32,600 USD",
   "data_price": 32600
 },{
@@ -151,7 +151,7 @@
   "VEHICLE CLASS": "Compact",
   "ENGINE POWER": "60 kW",
   "BATTERY CAPACITY": "22 kWh",
-  "m/kWh": "0.38 kWh",
+  "m/kWh": 0.38,
   "PRICE": "25,500 USD",
   "data_price": 25500
 },{
@@ -164,7 +164,7 @@
   "VEHICLE CLASS": "SUV",
   "ENGINE POWER": "44 million horsepower",
   "BATTERY CAPACITY": "Rocket size kWh",
-  "m/kWh": " Hypersonic kWh",
+  "m/kWh": 999,
   "PRICE": "69,900 USD",
   "data_price": 69900
 },{
@@ -177,7 +177,7 @@
   "VEHICLE CLASS": "SUV",
   "ENGINE POWER": "150 kW",
   "BATTERY CAPACITY": "78 kWh",
-  "m/kWh": "0.43 kWh",
+  "m/kWh": 0.43,
   "PRICE": "56,395 USD",
   "data_price": 56395
 },{
@@ -190,7 +190,7 @@
   "VEHICLE CLASS": "Mid-Size",
   "ENGINE POWER": "160 kW",
   "BATTERY CAPACITY": "93.4 kWh",
-  "m/kWh": "0.5 kWh",
+  "m/kWh": 0.5,
   "PRICE": "187,610 UDS",
   "data_price": 187610
 },{
@@ -203,7 +203,7 @@
   "VEHICLE CLASS": "Mid-Size",
   "ENGINE POWER": "300 kW",
   "BATTERY CAPACITY": "78 kWh",
-  "m/kWh": "0.37 kWh",
+  "m/kWh": 0.37,
   "PRICE": "63,000 USD",
   "data_price": 63000
 },{
@@ -216,7 +216,7 @@
   "VEHICLE CLASS": "SUV",
   "ENGINE POWER": "300 kW",
   "BATTERY CAPACITY": "80 kWh",
-  "m/kWh": " 0.35 kWh",
+  "m/kWh": 0.35,
   "PRICE": "67,900 USD",
   "data_price": 67900
 },{
@@ -229,7 +229,7 @@
   "VEHICLE CLASS": "SUV",
   "ENGINE POWER": "147 kW",
   "BATTERY CAPACITY": "90 kWh",
-  "m/kWh": " 0.44 kWh",
+  "m/kWh": 0.44,
   "PRICE": "69,500 USD",
   "data_price": 69500
 },{
@@ -242,7 +242,7 @@
   "VEHICLE CLASS": "SUV",
   "ENGINE POWER": "140 kW",
   "BATTERY CAPACITY": "95 kWh",
-  "m/kWh": "0.46 kWh",
+  "m/kWh": 0.46,
   "PRICE": "81,800 USD",
   "data_price": 81800
 },{
@@ -255,7 +255,7 @@
   "VEHICLE CLASS": "SUV",
   "ENGINE POWER": "375 kW",
   "BATTERY CAPACITY": "100 kWh",
-  "m/kWh": "0.43 kWh",
+  "m/kWh": 0.43,
   "PRICE": "99,990 USD",
   "data_price": 99990
 }]


### PR DESCRIPTION
# feat: add individual car savings per year to the car search results display

## Pull Request References:

## PR Includes:

### ADDITIONS
- individual car savings calculation formula added to current calculation function
- calculates savings dependant on the individual cars miles per kWh data
- only displays is positive result
- calculations react to the data entered into the calculator above

### UPDATES

### DELETED/REMOVED ITEMS/FEATURES

## Breaking changes
None

## Screenshots/Gifs/Media
![image](https://user-images.githubusercontent.com/68779486/164989747-20b53736-dc55-4ad7-82a5-399eeff35dda.png)
